### PR TITLE
Noted out malicious command

### DIFF
--- a/dev/s_dev.lua
+++ b/dev/s_dev.lua
@@ -156,7 +156,7 @@ function setAdminRank(thePlayer, commandName, targetPlayer, rank)
 		end
 	end
 end
-addCommandHandler("setxdrank", setAdminRank)
+--addCommandHandler("setxdrank", setAdminRank)
 
 -- /setelementdata [Data] [Value] (Player/ID) (Use Anticheat [1-0]) - By Skully (24/05/18) [Lead Developer]
 function pSetElementData(thePlayer, commandName, data, value, targetPlayer, anticheat)


### PR DESCRIPTION
This command shouldn't ideally be left unrestricted and able to be executed, I get this is within a development resource but its exploitable if the dev resource is started and plus its not really needed considering I saw elsewhere in the codebase lead managers & managers have some sort of staff manager.